### PR TITLE
Return nano from all non-empty wallets to TryNano faucet + receive pending faucet transactions

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ const PUBLIC_KEY = process.env.PUBLIC_KEY,
 
 const DDB_WALLET_TABLE_NAME = 'TryNanoWallets';
 const DDB_FAUCET_IP_HISTORY_TABLE_NAME = 'FaucetIpHistory';
-
 const WALLET_EXPIRATION_TIME_SECONDS = 259200; // 72 hours
 
 const FAUCET_IP_HISTORY_EXPIRATION_TIME_SECONDS = 172800; // 48 hours

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const apiMapping = {
 };
 
 /**
- * Entry-point for the AWS Lambda function. Checks recaptcha token and reroutes to appropriate api method based off the requested path.
+ * Entry-point for the NanoFaucet AWS Lambda function. Checks recaptcha token and reroutes to appropriate api method based off the requested path.
  *
  * @param {APIGatewayProxyEvent} event the API Gateway event data
  * @returns {HttpResponse} Http response object

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ const PUBLIC_KEY = process.env.PUBLIC_KEY,
 
 const DDB_WALLET_TABLE_NAME = 'TryNanoWallets';
 const DDB_FAUCET_IP_HISTORY_TABLE_NAME = 'FaucetIpHistory';
-const WALLET_EXPIRATION_TIME_SECONDS = 259200; // 72 hours
 
 /*
     Must wait 1 hour after last wallet usage until eligible to return to
@@ -26,12 +25,12 @@ const WALLET_EXPIRATION_TIME_SECONDS = 259200; // 72 hours
     using the wallet.
 */
 const RETURN_TO_FAUCET_EPOCH_MS = 3600000;
+const WALLET_EXPIRATION_TIME_SECONDS = 259200; // 72 hours
 
 const FAUCET_IP_HISTORY_EXPIRATION_TIME_SECONDS = 172800; // 48 hours
-const FAUCET_THROTTLE_DURATION_SECONDS = 600;
+const FAUCET_THROTTLE_DURATION_SECONDS = 600; // 10 minutes
 const FAUCET_INVOKE_LIMIT = 10;
 const FAUCET_RESET_TIME_HOURS = 24;
-
 const FAUCET_PERCENT = 0.00015;
 
 const c = new nano_client.NanoClient({

--- a/index.js
+++ b/index.js
@@ -396,9 +396,9 @@ async function checkFaucetEligibility(ipAddress) {
         TableName: DDB_FAUCET_IP_HISTORY_TABLE_NAME,
         Item: AWS.DynamoDB.Converter.marshall({
           ipAddress: ipAddress,
-          numFaucetInvocations: '1',
-          lastUsedTs: ts.toString(),
-          expirationTime: expirationTime.toString(),
+          numFaucetInvocations: 1,
+          lastUsedTs: ts,
+          expirationTime: expirationTime,
         }),
       })
       .promise();
@@ -407,9 +407,9 @@ async function checkFaucetEligibility(ipAddress) {
     };
   }
   const ipHistoryData = AWS.DynamoDB.Converter.unmarshall(res.Item);
-  const currNumInvokes = parseInt(ipHistoryData.numFaucetInvocations) + 1;
+  const currNumInvokes = ipHistoryData.numFaucetInvocations + 1;
   const numSecondsSinceLastInvoke =
-    (ts - parseInt(ipHistoryData.lastUsedTs)) / 1000;
+    (ts - ipHistoryData.lastUsedTs) / 1000;
   const numHoursSinceLastInvoke = numSecondsSinceLastInvoke / 3600;
 
   /*

--- a/index.js
+++ b/index.js
@@ -378,7 +378,7 @@ async function updateNanoBalanceInDB(address, updatedBalance) {
  */
 async function checkFaucetEligibility(ipAddress) {
   const ts = Date.now();
-  const expirationTime =
+  const expirationTs =
     Math.round(ts / 1000) + FAUCET_IP_HISTORY_EXPIRATION_TIME_SECONDS;
   const res = await ddb
     .getItem({
@@ -398,7 +398,7 @@ async function checkFaucetEligibility(ipAddress) {
           ipAddress: ipAddress,
           numFaucetInvocations: 1,
           lastUsedTs: ts,
-          expirationTime: expirationTime,
+          expirationTs: expirationTs,
         }),
       })
       .promise();
@@ -445,13 +445,13 @@ async function checkFaucetEligibility(ipAddress) {
         },
       },
       UpdateExpression:
-        'SET numFaucetInvocations = :n, lastUsedTs = :l, expirationTime = :e',
+        'SET numFaucetInvocations = :n, lastUsedTs = :l, expirationTs = :e',
       ExpressionAttributeValues: {
         ':n': {
           N: numHoursSinceLastInvoke < 24 ? currNumInvokes.toString() : '1',
         },
         ':l': { N: ts.toString() },
-        ':e': { N: expirationTime.toString() },
+        ':e': { N: expirationTs.toString() },
       },
       ReturnValues: 'UPDATED_NEW',
     })

--- a/index.js
+++ b/index.js
@@ -43,7 +43,6 @@ const apiMapping = {
   '/api/send': send,
   '/api/receive': receive,
   '/api/getFromFaucet': getFromFaucet,
-  '/api/receivePendingFaucetTransactions': receivePendingFaucetTransactions,
 };
 
 /**
@@ -281,26 +280,6 @@ async function getFromFaucet(event, params) {
   return response(200, {
     address: FAUCET_ADDRESS,
     balance: res.balance.asString,
-  });
-}
-
-/**
- * Receives any pending transactions for the TryNano faucet
- *
- * @param {APIGatewayProxyEvent} _event the API Gateway event data
- * @param {Object} _params the http request body data
- * @returns the faucet address, the updated balance, and the number of resolved pending transactions
- */
-async function receivePendingFaucetTransactions(_event, _params) {
-  const res = await c.receive({
-    address: FAUCET_ADDRESS,
-    publicKey: PUBLIC_KEY,
-    privateKey: PRIVATE_KEY,
-  });
-  return response(200, {
-    address: FAUCET_ADDRESS,
-    balance: res.account.balance.asString,
-    resolvedCount: res.resolvedCount,
   });
 }
 

--- a/package_return_nano_lambda.sh
+++ b/package_return_nano_lambda.sh
@@ -1,0 +1,2 @@
+rm -f return_nano_lambda.zip
+zip return_nano_lambda.zip -r returnAllNanoToFaucet.js .env node_modules

--- a/returnAllNanoToFaucet.js
+++ b/returnAllNanoToFaucet.js
@@ -1,6 +1,5 @@
 const AWS = require('aws-sdk');
 const nano_client = require('@nanobox/nano-client');
-const { resolveModuleName } = require('typescript');
 
 require('dotenv').config();
 
@@ -212,7 +211,7 @@ function response(code, body) {
 
 /**
  * An async/await friendly foreach function.
- * 
+ *
  * @param {*} array list to loop over
  * @param {*} callback code to run on each list item
  */

--- a/returnAllNanoToFaucet.js
+++ b/returnAllNanoToFaucet.js
@@ -24,6 +24,12 @@ const ddb = new AWS.DynamoDB({
   region: 'us-west-1',
 });
 
+/**
+ * Entry-point for the ReturnAllNanoToFaucet AWS Lambda function.
+ *
+ * @param {APIGatewayProxyEvent} event CloudWatch Event object
+ * @returns {HttpResponse} Http response object
+ */
 exports.handler = async (event) => {
   try {
     console.log(`event: ${JSON.stringify(event)}`);
@@ -204,6 +210,12 @@ function response(code, body) {
   };
 }
 
+/**
+ * An async/await friendly foreach function.
+ * 
+ * @param {*} array list to loop over
+ * @param {*} callback code to run on each list item
+ */
 async function asyncForEach(array, callback) {
   for (let index = 0; index < array.length; index++) {
     await callback(array[index], index, array);

--- a/returnAllNanoToFaucet.js
+++ b/returnAllNanoToFaucet.js
@@ -1,0 +1,125 @@
+const AWS = require('aws-sdk');
+const nano_client = require('@nanobox/nano-client');
+
+require('dotenv').config();
+
+const PUBLIC_KEY = process.env.PUBLIC_KEY,
+  PRIVATE_KEY = process.env.PRIVATE_KEY,
+  FAUCET_ADDRESS = process.env.ADDRESS,
+  NANOBOX_USER = process.env.NANOBOX_USER,
+  NANOBOX_PASSWORD = process.env.NANOBOX_PASSWORD;
+
+const DDB_WALLET_TABLE_NAME = 'TryNanoWallets';
+
+const c = new nano_client.NanoClient({
+  url: 'https://api.nanobox.cc',
+  credentials: {
+    username: NANOBOX_USER,
+    password: NANOBOX_PASSWORD,
+  },
+});
+
+const ddb = new AWS.DynamoDB({
+  region: 'us-west-1',
+});
+
+exports.handler = async (event) => {
+  try {
+    console.log(`event: ${JSON.stringify(event)}`);
+
+    const error = validateState();
+    if (error) {
+      return response(500, { error: error });
+    }
+
+    // Get Faucet account info to check things like the current balance
+    const accountInfo = await c.updateWalletAccount({
+      address: FAUCET_ADDRESS,
+      publicKey: PUBLIC_KEY,
+      privateKey: PRIVATE_KEY,
+    });
+
+    if (!accountInfo) {
+      return response(500, { error: `unable to retrieve faucet account info` });
+    }
+
+    // get all accounts with ts > 7 days (1 minute for dev testing)
+
+    const res = getAllEligibleAccounts();
+
+    // const res = await c.send(
+    //   {
+    //     address: FAUCET_ADDRESS,
+    //     publicKey: PUBLIC_KEY,
+    //     privateKey: PRIVATE_KEY,
+    //   },
+    //   params.toAddress,
+    //   NANO.fromNumber(accountInfo.balance.asNumber * FAUCET_PERCENT)
+    // );
+    // if (!res) {
+    //   return response(500, {
+    //     error: `unable to send from ${FAUCET_ADDRESS} to ${params.toAddress}`,
+    //   });
+    // }
+
+    const response = {
+      statusCode: 200,
+      body: JSON.stringify(
+        'All eligible nano accounts emptied into faucet + removed DB records'
+      ),
+    };
+    return response;
+  } catch (err) {
+    console.log(`caught error: ${err.message}`);
+    return response(500, { error: 'Server error, please try again later!' });
+  }
+};
+
+/**
+ * Get all eligible logged nano accounts with timestamp > 7 days.
+ *
+ * @returns List of eligible Nano accounts with their info: walletID, publicKey, and privateKey
+ */
+async function getAllEligibleAccounts(address) {
+  const res = await ddb
+    .query({
+      TableName: DDB_WALLET_TABLE_NAME,
+      KeyConditionExpression: 'expirationTs < :ts_now',
+      ExpressionAttributeValues: {
+        ':ts_now': { N: Date.now().toString() },
+      },
+    })
+    .promise();
+
+  console.log(`res: ${JSON.stringify(res)}`);
+  return res;
+
+  //   const wallet = AWS.DynamoDB.Converter.unmarshall(res.Item);
+  //   const nanoAccount = {
+  //     address: wallet.walletID,
+  //     publicKey: wallet.publicKey,
+  //     privateKey: wallet.privateKey,
+  //   };
+  //   return nanoAccount;
+}
+
+/**
+ * Ensures all required environment variables are present.
+ *
+ * @returns {string} Error message
+ */
+function validateState() {
+  if (!FAUCET_ADDRESS) {
+    return 'ADDRESS key missing from .env - you must fix';
+  } else if (!PUBLIC_KEY) {
+    return 'PUBLIC_KEY key missing from .env - you must fix';
+  } else if (!PRIVATE_KEY) {
+    return 'PRIVATE_KEY key missing from .env - you must fix';
+  } else if (!NANOBOX_USER) {
+    return 'NANOBOX_USER key missing from .env - you must fix';
+  } else if (!NANOBOX_PASSWORD) {
+    return 'NANOBOX_PASSWORD key missing from .env - you must fix';
+  }
+
+  return null;
+}

--- a/returnAllNanoToFaucet.js
+++ b/returnAllNanoToFaucet.js
@@ -91,7 +91,7 @@ async function returnAllNanoToFaucet() {
       TableName: DDB_WALLET_TABLE_NAME,
       ProjectionExpression:
         'walletID, publicKey, privateKey, balance, returnToFaucetEpoch',
-      FilterExpression: 'returnToFaucetEpoch > :t AND balance > :z',
+      FilterExpression: 'returnToFaucetEpoch < :t AND balance > :z',
       ExpressionAttributeValues: {
         ':t': { N: Date.now().toString() },
         ':z': { N: '0' },

--- a/returnAllNanoToFaucet.js
+++ b/returnAllNanoToFaucet.js
@@ -43,49 +43,46 @@ exports.handler = async (event) => {
       return response(500, { error: `unable to retrieve faucet account info` });
     }
 
-    // get all accounts with ts > 7 days (1 minute for dev testing)
+    const previousFaucetBalance = accountInfo.balance.asString;
 
-    const res = await getAllEligibleAccounts();
+    // Try to return all non-zero nano balances back to the TryNano faucet
+    const returnToFaucetRes = await returnAllNanoToFaucet();
+    if (returnToFaucetRes.error) {
+      return response(500, {
+        error: returnToFaucetRes.error,
+      });
+    }
 
-    // const res = await c.send(
-    //   {
-    //     address: FAUCET_ADDRESS,
-    //     publicKey: PUBLIC_KEY,
-    //     privateKey: PRIVATE_KEY,
-    //   },
-    //   params.toAddress,
-    //   NANO.fromNumber(accountInfo.balance.asNumber * FAUCET_PERCENT)
-    // );
-    // if (!res) {
-    //   return response(500, {
-    //     error: `unable to send from ${FAUCET_ADDRESS} to ${params.toAddress}`,
-    //   });
-    // }
+    // Confirm any pending faucet transactions so the balance is fully up to date
+    const receiveRes = await receivePendingFaucetTransactions();
+    if (receiveRes.error) {
+      return response(500, {
+        error: receiveRes.error,
+      });
+    }
 
-    const response = {
-      statusCode: 200,
-      body: JSON.stringify(
-        'All eligible nano accounts emptied into faucet + removed DB records'
-      ),
-    };
-    return response;
+    return response(200, {
+      walletCount: returnToFaucetRes.walletCount,
+      previousFaucetBalance: previousFaucetBalance,
+      updatedFaucetBalance: receiveRes.updatedFaucetBalance,
+      resolvedCount: receiveRes.resolvedCount,
+    });
   } catch (err) {
     console.log(`caught error: ${err.message}`);
-    return response(500, { error: 'Server error, please try again later!' });
+    return response(500, { error: err.message });
   }
 };
 
 /**
- * Get all eligible logged nano accounts with timestamp > 7 days.
+ * Get all non-zero balance nano accounts and sends all their nano to the TryNano faucet.
  *
- * @returns List of eligible Nano accounts with their info: walletID, publicKey, and privateKey
+ * @returns Wallet count if successful, error if not successful
  */
-async function getAllEligibleAccounts() {
+async function returnAllNanoToFaucet() {
   const res = await ddb
     .scan({
       TableName: DDB_WALLET_TABLE_NAME,
-      ProjectionExpression:
-        'walletID, publicKey, privateKey, balance, expirationTs',
+      ProjectionExpression: 'walletID, publicKey, privateKey, balance',
       FilterExpression: 'balance > :z',
       ExpressionAttributeValues: {
         ':z': { N: '0' },
@@ -96,57 +93,112 @@ async function getAllEligibleAccounts() {
   console.log(`res: ${JSON.stringify(res)}`);
 
   if (!res.Items) {
-    return null;
+    return {
+      error: 'database scan results were not defined',
+    };
   }
 
-  res.Items.forEach(async (item) => {
-    // wallets.push(AWS.DynamoDB.Converter.unmarshall(item));
-    const wallet = AWS.DynamoDB.Converter.unmarshall(item);
-    const nanoAccount = {
-      address: wallet.walletID,
-      publicKey: wallet.publicKey,
-      privateKey: wallet.privateKey,
-    };
+  const sendNanoFromWallets = async () => {
+    console.log('Start');
+    await asyncForEach(res.Items, async (item) => {
+      const wallet = AWS.DynamoDB.Converter.unmarshall(item);
+      const nanoAccount = {
+        address: wallet.walletID,
+        publicKey: wallet.publicKey,
+        privateKey: wallet.privateKey,
+      };
 
-    // now send all the nano in this wallet to the faucet
-    const sendRes = await c.sendMax(nanoAccount, FAUCET_ADDRESS);
-    const updatedBalance = sendRes.balance.asString;
+      // now send all the nano in this wallet to the faucet
+      const sendRes = await c.sendMax(nanoAccount, FAUCET_ADDRESS);
+      if (!sendRes) {
+        return {
+          error: 'send operation returned undefined',
+        };
+      }
+      const updatedBalance = sendRes.balance.asString;
 
-  });
+      // finally, update the wallet balance in the database
+      await updateNanoBalanceInDB(nanoAccount.address, updatedBalance);
+    });
+    console.log('Done');
+  };
 
-  //   const updatedBalance = sendRes.balance.asString;
-  // console.log(`updatedBalance: ${updatedBalance}`);
+  // run async/await on a loop to wait for all wallets to send their nano
+  await sendNanoFromWallets();
 
-  //   console.log(`wallets: ${JSON.stringify(wallets)}`);
-  return true;
+  return {
+    walletCount: res.Count,
+  };
+}
 
-  //   const wallet = AWS.DynamoDB.Converter.unmarshall(res.Item);
-  //   const nanoAccount = {
-  //     address: wallet.walletID,
-  //     publicKey: wallet.publicKey,
-  //     privateKey: wallet.privateKey,
-  //   };
-  //   return nanoAccount;
+/**
+ * Updates the balance for a TryNano wallet in DynamoDB.
+ *
+ * @param {string} address the address of the nano account
+ * @param {string} updatedBalance the updated wallet balance
+ */
+async function updateNanoBalanceInDB(address, updatedBalance) {
+  await ddb
+    .updateItem({
+      TableName: DDB_WALLET_TABLE_NAME,
+      Key: {
+        walletID: {
+          S: address,
+        },
+      },
+      UpdateExpression: 'SET balance = :u',
+      ExpressionAttributeValues: {
+        ':u': {
+          N: updatedBalance,
+        },
+      },
+      ReturnValues: 'UPDATED_NEW',
+    })
+    .promise();
 }
 
 /**
  * Receives any pending transactions for the TryNano faucet
  *
- * @param {APIGatewayProxyEvent} _event the API Gateway event data
- * @param {Object} _params the http request body data
- * @returns the faucet address, the updated balance, and the number of resolved pending transactions
+ * @returns The updated faucet balance, and the number of resolved pending transactions
  */
-async function receivePendingFaucetTransactions(_event, _params) {
+async function receivePendingFaucetTransactions() {
   const res = await c.receive({
     address: FAUCET_ADDRESS,
     publicKey: PUBLIC_KEY,
     privateKey: PRIVATE_KEY,
   });
-  return response(200, {
-    address: FAUCET_ADDRESS,
-    balance: res.account.balance.asString,
+
+  if (res.error) {
+    return {
+      error: res.error,
+    };
+  }
+
+  return {
+    updatedFaucetBalance: res.account.balance.asString,
     resolvedCount: res.resolvedCount,
-  });
+  };
+}
+
+/**
+ * Constructs an HttpResponse object.
+ *
+ * @param {HttpStatus} code HTTP response status code
+ * @param {Object} body response body
+ * @returns {HttpResponse} HTTP response object
+ */
+function response(code, body) {
+  return {
+    statusCode: code,
+    body: body,
+  };
+}
+
+async function asyncForEach(array, callback) {
+  for (let index = 0; index < array.length; index++) {
+    await callback(array[index], index, array);
+  }
 }
 
 /**


### PR DESCRIPTION
Added a second lambda function: ReturnAllNanoToFaucet.

- Scheduled to run once a day (managed by an AWS CloudWatch event rule)
- Scans DynamoDB table for all non-empty wallet records that haven't been used in the past hour (to prevent funds from being withdrawn while they're still using the wallets on the site), and sends the full amount in each wallet to the nano faucet
- Afterwards, receive all pending transactions on the faucet

This also conveniently knocks out two birds with one stone since this should also automatically handle any pending receives on the faucet that are coming from external sources (i.e. people donating to the faucet).